### PR TITLE
Allow dynamic API location

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+var PI_URI_BASE = null;
 init();
 checkStatus();  //Get the current status when the browser opens
 window.setInterval(checkStatus, 30000); //Keep checking every 30 seconds
@@ -5,7 +6,6 @@ window.setInterval(checkStatus, 30000); //Keep checking every 30 seconds
 //Get the current status
 function checkStatus() {
     var httpResponse = new XMLHttpRequest();    //make a new request
-
     httpResponse.onreadystatechange = function () {
         if (this.readyState == 4 && this.status == 200) {
             // Action to be performed when the document is read;
@@ -23,13 +23,24 @@ function checkStatus() {
             chrome.browserAction.setBadgeText({ text: "" });
         }
     };
-    httpResponse.open("GET", "http://pi.hole/admin/api.php?", true);
+    httpResponse.open("GET", PI_URI_BASE+"/admin/api.php?", true);
     httpResponse.send();
 }
 
-
 function init()
 {
+	chrome.storage.local.get('pi_uri_base', function (data) {
+		if(data.pi_uri_base == '')
+        {
+			chrome.storage.local.set({pi_uri_base: "http://pi.hole"}, function () {
+                console.log("Set default URL to http://pi.hole");
+            });
+        } else {
+			console.log("Current URI base: "+data.pi_uri_base);
+		} 
+		PI_URI_BASE = data.pi_uri_base;
+    });
+	
     chrome.storage.local.getBytesInUse(['max_time'], function(bytes){
         if(bytes == 0)
         {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Remote Switch for Pi-Hole",
-    "version": "2.0",
+    "version": "2.1",
     "author": "Spencer Yoder",
 
     "description": "Lets you Enable/Disable a Pi-Hole with out opening a new tab.",
@@ -31,6 +31,6 @@
 
       "permissions": [
         "storage",
-        "http://pi.hole/*",
+        "http://*/*",
         "webRequest"]
   }

--- a/options/options.html
+++ b/options/options.html
@@ -10,10 +10,15 @@
 
         <table>
             <tr>
+                <td><p>Pi-Hole Address:</p></td>
+                <td><input type="text" id="pi_uri_base" name="Pi-Hole Address"></td>
+            </tr>
+
+			<tr>
                 <td><p>API Key:</p></td>
                 <td><input type="text" id="api_key" name="API Key"></td>
             </tr>
-
+			
             <tr>
                 <td><p>Max Disable Time:</p></td>
                 <td><input type="text" id="max_time" name="Max Time"></td>

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,6 @@
 //Function that saves the key to storage
 function setStorage() {
-    chrome.storage.local.set({api_key: document.getElementById("api_key").value, max_time: document.getElementById("max_time").value}, function () {
+    chrome.storage.local.set({pi_uri_base: document.getElementById("pi_uri_base").value, api_key: document.getElementById("api_key").value, max_time: document.getElementById("max_time").value}, function () {
         document.getElementById("confirmation_status").innerHTML = "Saved Successful!";
     });
 }
@@ -8,6 +8,7 @@ function setStorage() {
 //Function that get the API key from the storage
 function getStorage() {
     chrome.storage.local.get(null, function (data) {
+		document.getElementById("pi_uri_base").defaultValue = data.pi_uri_base;
         document.getElementById("api_key").defaultValue = data.api_key;
         document.getElementById("max_time").defaultValue = data.max_time;
     });

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,8 +1,10 @@
 var API_KEY = null; //Temporary variable for the API-Key 
 var MAX_TIME = null;
+var PI_URI_BASE = null;
 
 //Function called after the enable/disable button is pressed.
 function buttonClicked() {
+	getStorage();   //get the API key from local storage
     var httpResponse = new XMLHttpRequest();    //Make a new object to accept return from server
     var url = null;
 
@@ -23,11 +25,11 @@ function buttonClicked() {
         console.log(time + "***");
 
         //time = time * 60;   //get it in minutes
-        url = "http://pi.hole/admin/api.php?disable=" + String(time) + "&auth=" + API_KEY;  //build the url
+        url = PI_URI_BASE+"/admin/api.php?disable=" + String(time) + "&auth=" + API_KEY;  //build the url
     }
 
     else if (!document.getElementById("sliderBox").checked) {
-        url = "http://pi.hole/admin/api.php?enable&auth=" + API_KEY;    //build the url
+        url = PI_URI_BASE+"/admin/api.php?enable&auth=" + API_KEY;    //build the url
     }
 
     httpResponse.onreadystatechange = function () {
@@ -54,7 +56,7 @@ function getPiHoleStatus() {
             changeIcon(data);
         }
     };
-    httpResponse.open("GET", "http://pi.hole/admin/api.php?", true);
+    httpResponse.open("GET", PI_URI_BASE+"/admin/api.php?", true);
     httpResponse.send();
 }
 
@@ -86,6 +88,10 @@ function changeIcon(data) {
 
 //Function thats the API key from local storage
 function getStorage() {
+	chrome.storage.local.get('pi_uri_base', function (data) {
+        PI_URI_BASE = data.pi_uri_base;
+    });
+	
     chrome.storage.local.get('api_key', function (data) {
         API_KEY = data.api_key;
     });


### PR DESCRIPTION
QDOS for #3 
Sorry for the ugly PR, no dev env on my laptop.
Points of note:
- Manifest is now universal ` http://*/*` permission, haven't done extensions before so that's the best I could come up with in a pinch.
- The first check to the API fails, something to do with variable initialization i think. Again, JS isn't my cup of tea. The following checks sync up properly though.
- Not sure what versioning metric your using, so i just incremented to 2.1

Hopefully this is at least helpful enough for you to quickly fix my little bugs.